### PR TITLE
明示的な参照セマンティクスにする

### DIFF
--- a/Sources/CxxSwiftOpenXLSX/include/SXLCellFormats.hpp
+++ b/Sources/CxxSwiftOpenXLSX/include/SXLCellFormats.hpp
@@ -2,6 +2,6 @@
 
 #include "./SXLCommon.hpp"
 
-size_t XLCellFormats_count(const OpenXLSX::XLCellFormats & self);
-OpenXLSX::XLCellFormat XLCellFormats_cellFormatByIndex(const OpenXLSX::XLCellFormats & self, size_t index);
-size_t XLCellFormats_create(const OpenXLSX::XLCellFormats & self);
+size_t XLCellFormats_count(const OpenXLSX::XLCellFormats * self);
+OpenXLSX::XLCellFormat XLCellFormats_cellFormatByIndex(const OpenXLSX::XLCellFormats * self, size_t index);
+size_t XLCellFormats_create(const OpenXLSX::XLCellFormats * self);

--- a/Sources/CxxSwiftOpenXLSX/include/SXLNumberFormats.hpp
+++ b/Sources/CxxSwiftOpenXLSX/include/SXLNumberFormats.hpp
@@ -2,6 +2,6 @@
 
 #include "./SXLCommon.hpp"
 
-size_t XLNumberFormats_count(const OpenXLSX::XLNumberFormats & self);
-OpenXLSX::XLNumberFormat XLNumberFormats_numberFormatByIndex(const OpenXLSX::XLNumberFormats & self, OpenXLSX::XLStyleIndex index);
-OpenXLSX::XLStyleIndex XLNumberFormats_create(const OpenXLSX::XLNumberFormats & self);
+size_t XLNumberFormats_count(const OpenXLSX::XLNumberFormats * self);
+OpenXLSX::XLNumberFormat XLNumberFormats_numberFormatByIndex(const OpenXLSX::XLNumberFormats * self, OpenXLSX::XLStyleIndex index);
+OpenXLSX::XLStyleIndex XLNumberFormats_create(const OpenXLSX::XLNumberFormats * self);

--- a/Sources/CxxSwiftOpenXLSX/src/SXLCellFormats.cpp
+++ b/Sources/CxxSwiftOpenXLSX/src/SXLCellFormats.cpp
@@ -2,14 +2,14 @@
 
 using namespace OpenXLSX;
 
-size_t XLCellFormats_count(const OpenXLSX::XLCellFormats & self) {
-    return self.count();
+size_t XLCellFormats_count(const OpenXLSX::XLCellFormats * self) {
+    return self->count();
 }
 
-OpenXLSX::XLCellFormat XLCellFormats_cellFormatByIndex(const OpenXLSX::XLCellFormats & self, size_t index) {
-    return self.cellFormatByIndex(index);
+OpenXLSX::XLCellFormat XLCellFormats_cellFormatByIndex(const OpenXLSX::XLCellFormats * self, size_t index) {
+    return self->cellFormatByIndex(index);
 }
 
-size_t XLCellFormats_create(const OpenXLSX::XLCellFormats & self) {
-    return const_cast<XLCellFormats &>(self).create();
+size_t XLCellFormats_create(const OpenXLSX::XLCellFormats * self) {
+    return const_cast<XLCellFormats *>(self)->create();
 }

--- a/Sources/CxxSwiftOpenXLSX/src/SXLNumberFormats.cpp
+++ b/Sources/CxxSwiftOpenXLSX/src/SXLNumberFormats.cpp
@@ -2,14 +2,14 @@
 
 using namespace OpenXLSX;
 
-size_t XLNumberFormats_count(const OpenXLSX::XLNumberFormats & self) {
-    return self.count();
+size_t XLNumberFormats_count(const OpenXLSX::XLNumberFormats * self) {
+    return self->count();
 }
 
-OpenXLSX::XLNumberFormat XLNumberFormats_numberFormatByIndex(const OpenXLSX::XLNumberFormats & self, OpenXLSX::XLStyleIndex index) {
-    return self.numberFormatByIndex(index);
+OpenXLSX::XLNumberFormat XLNumberFormats_numberFormatByIndex(const OpenXLSX::XLNumberFormats * self, OpenXLSX::XLStyleIndex index) {
+    return self->numberFormatByIndex(index);
 }
 
-OpenXLSX::XLStyleIndex XLNumberFormats_create(const OpenXLSX::XLNumberFormats & self) {
-    return const_cast<XLNumberFormats &>(self).create();
+OpenXLSX::XLStyleIndex XLNumberFormats_create(const OpenXLSX::XLNumberFormats * self) {
+    return const_cast<XLNumberFormats *>(self)->create();
 }

--- a/Sources/SwiftOpenXLSX/XLCellFormats.swift
+++ b/Sources/SwiftOpenXLSX/XLCellFormats.swift
@@ -3,14 +3,14 @@ import CxxSwiftXLSX
 public struct XLCellFormats: BidirectionalCollection {
     init(
         document: XLDocument,
-        formats: OpenXLSX.XLCellFormats
+        formats: UnsafeMutablePointer<OpenXLSX.XLCellFormats>
     ) {
         self.document = document
         self.formats = formats
     }
     
     var document: XLDocument
-    var formats: OpenXLSX.XLCellFormats
+    var formats: UnsafeMutablePointer<OpenXLSX.XLCellFormats>
 
     public var count: Int {
         XLCellFormats_count(formats)

--- a/Sources/SwiftOpenXLSX/XLNumberFormats.swift
+++ b/Sources/SwiftOpenXLSX/XLNumberFormats.swift
@@ -1,13 +1,16 @@
 import CxxSwiftXLSX
 
 public struct XLNumberFormats: BidirectionalCollection {
-    init(document: XLDocument, formats: OpenXLSX.XLNumberFormats) {
+    init(
+        document: XLDocument,
+        formats: UnsafeMutablePointer<OpenXLSX.XLNumberFormats>
+    ) {
         self.document = document
         self.formats = formats
     }
     
     var document: XLDocument
-    var formats: OpenXLSX.XLNumberFormats
+    var formats: UnsafeMutablePointer<OpenXLSX.XLNumberFormats>
 
     public var count: Int {
         XLNumberFormats_count(formats)

--- a/Sources/SwiftOpenXLSX/XLStyles.swift
+++ b/Sources/SwiftOpenXLSX/XLStyles.swift
@@ -15,14 +15,14 @@ public struct XLStyles {
     public var numberFormats: XLNumberFormats {
         return XLNumberFormats(
             document: document,
-            formats: XLStyles_numberFormats(styles.pointee).pointee
+            formats: XLStyles_numberFormats(styles.pointee)
         )
     }
 
     public var cellFormats: XLCellFormats {
         return XLCellFormats(
             document: document,
-            formats: XLStyles_cellFormats(styles.pointee).pointee
+            formats: XLStyles_cellFormats(styles.pointee)
         )
     }
 }


### PR DESCRIPTION
const referenceはSwift側が値コピーを挿入することがわかった
アドレス変化させないため明確にポインタで扱う